### PR TITLE
Changes to run generated python in python 3

### DIFF
--- a/XBVC/emitters/EmitterBase.py
+++ b/XBVC/emitters/EmitterBase.py
@@ -1,6 +1,6 @@
 import os.path
 from jinja2 import Environment, FileSystemLoader
-import inspect, os
+import os
 import os.path
 
 class SourceFile(object):
@@ -9,7 +9,7 @@ class SourceFile(object):
         self.name = name
 
     def save_to_disk(self, path):
-        with open(os.path.join(path, self.name), 'wb') as f:
+        with open(os.path.join(path, self.name), 'w') as f:
             f.write(self.content)
 
     def __str__(self):
@@ -24,16 +24,14 @@ class Emitter(object):
     def generate_source(self, commspec, targets):
         pass
 
-    def expand_template(self, template_name, template_vars = {}):
+    def expand_template(self, template_name, template_vars={}):
         base_path = os.path.dirname(__file__)
         tmpl_path = os.path.abspath(os.path.join(base_path, 'templates'))
         env = Environment(loader=FileSystemLoader(tmpl_path))
 
         env.trim_blocks = True
         env.lstrip_blocks = True
-        
+
         tmpl = env.get_template(template_name)
         return tmpl.render(template_vars)
 
-
-        

--- a/XBVC/emitters/templates/cobs.py
+++ b/XBVC/emitters/templates/cobs.py
@@ -7,7 +7,7 @@
 
 # Encodes a list or tuple of bytes (data) using COBS
 # Returns the encoded data
-def cobs_encode(data = list()):
+def cobs_encode(data=list()):
     if not type(data) == list and not type(data) == tuple:
         raise TypeError("data must be a list or tuple")
 
@@ -15,7 +15,7 @@ def cobs_encode(data = list()):
     write_index = 1
     code_index = 0
     code = 1
-    output = (len(data) + 1 + (len(data) / 255)) * [0x00]
+    output = (len(data) + 1 + (len(data) // 255)) * [0x00]
 
     while read_index < len(data):
         if data[read_index] == 0:

--- a/XBVC/emitters/templates/py_interface.jinja2
+++ b/XBVC/emitters/templates/py_interface.jinja2
@@ -1,10 +1,9 @@
 import cobs
 import ctypes
 from threading import Event, Thread, Lock
-from Queue import Queue
+from queue import Queue
 
 import time
-import cPickle as pickle
 
 _ctypes_map = {
     'u32': ctypes.c_uint32,
@@ -47,7 +46,7 @@ def _encode_integer_to_bitvec(n, d_type):
         dst.append(0)
 
     return dst
-    
+
 def _decode_bitvec_from_list(lst, d_type):
     """
     Returns a tuple containing the first decoded integer and
@@ -119,18 +118,18 @@ class {{msg.name}}(_XBVCMessage):
         super({{msg.name}}, self).__init__()
         self.msg_id = {{msg.msg_id}}
         {% for m in msg.members %}
-	  {% if m.d_len == 1 %}
-	self.{{m.name}} = 0
-	  {% else %}
-	self.{{m.name}} = [0 for x in range({{m.d_len}})]
-	  {% endif %}
+      {% if m.d_len == 1 %}
+        self.{{m.name}} = 0
+      {% else %}
+        self.{{m.name}} = [0 for x in range({{m.d_len}})]
+      {% endif %}
         {% endfor %}
 
-	self._key = [
-	    {% for m in msg.members %}
-	    {'name':"{{m.name}}", 'len':{{m.d_len}}, 'type':'{{m.d_type}}'},
-	    {% endfor %}
-	]
+        self._key = [
+            {% for m in msg.members %}
+            {'name':"{{m.name}}", 'len':{{m.d_len}}, 'type':'{{m.d_type}}'},
+            {% endfor %}
+        ]
         if msg_pkt:
             self.decode(msg_pkt)
 
@@ -226,7 +225,7 @@ class XBVCEdgePoint(object):
         self._stop_event.clear()
         self._recv_thread_handle.daemon = True
         self._dispatch_thread_handle.daemon = True
-        
+
         self._recv_thread_handle.start()
         self._dispatch_thread_handle.start()
 
@@ -255,9 +254,9 @@ class XBVCEdgePoint(object):
                 self._sync_q.queue.clear()
 
         env = _encode_integer_to_bitvec(msg.msg_id, 'u32')
-     
+
         env.extend(msg.encode())
-     
+
         dat = cobs.cobs_encode(env)
 
         #We bookend packets with a '0' as a delimiter
@@ -320,8 +319,8 @@ class XBVCLoopbackEP(XBVCEdgePoint):
 
 if __name__ == '__main__':
     def msg_closure(m):
-        print "Async is sweet!"
-        print m
+        print("Async is sweet!")
+        print(m)
 
     msg = {{messages[0].name}}()
 
@@ -336,7 +335,7 @@ if __name__ == '__main__':
 
 
     #Test Synchronous comms
-    print ep.send(msg, msg.msg_id)
+    print(ep.send(msg, msg.msg_id))
 
     ep.stop()
-    
+


### PR DESCRIPTION
These changes allow the generated python to be run using python 3 and include just some necessary and some unnecessary formatting changes. 

With these changes made I was able to generate the new code into files and run xbvc_py.py with python 3.5.2. 
